### PR TITLE
Adding domains for EFF tracker blocker detection

### DIFF
--- a/hosts/hosts.txt
+++ b/hosts/hosts.txt
@@ -515,3 +515,7 @@
 # use finer grained hostnames?
 #127.0.0.1 tracking.applift.com
 
+# [EFF Tracker Detection]
+127.0.0.1 trackersimulator.org
+127.0.0.1 eviltracker.net
+127.0.0.1 do-not-tracker.org


### PR DESCRIPTION
These domains are for a new ad and tracker blocker detection application that we've written, soon to launch.  In order for us to have an accurate result for users of AdAway, you have to block these testing domains that we've set up.  Otherwise, our detection algorithm will show that users of AdAway are not blocking ads or trackers.